### PR TITLE
Refine Dependabot update schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,18 @@ updates:
   - package-ecosystem: npm
     directory: "/"
     schedule:
-      interval: weekly
+      interval: monthly
       time: "13:00"
+      timezone: Europe/Brussels
+    open-pull-requests-limit: 99
+    groups:
+      all:
+        patterns:
+          - "*"
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly
+      time: "11:00"
       timezone: Europe/Brussels
     open-pull-requests-limit: 99


### PR DESCRIPTION
- Group all dependencies into one
- Only update once a month
- Also update GA